### PR TITLE
docs(blog): update errata for Beweise Lernen

### DIFF
--- a/blog/2023-05-01-errata-beweisen-lernen/index.md
+++ b/blog/2023-05-01-errata-beweisen-lernen/index.md
@@ -21,28 +21,70 @@ Zum Hintergrund dieses Blog-Posts gibt es [weiter unten](#hintergrund-aufgabe-17
 
 
 :::info
-Stand 01.05.2023. Die neusten Notizen wurden zuerst in diese Liste überführt. Ich plane, die Liste sukzessive zu ergänzen.
+Stand 20.06.2023. Aktualisiert mit Vergleichslösungen, Metrische Räume und Äquivalenzklassen.
 :::
 
 
-| Seite                         | Fehlerstelle                                                           | Korrekturvorschlag                           | Bemerkung                                                                                          |
-|-------------------------------|------------------------------------------------------------------------|----------------------------------------------|----------------------------------------------------------------------------------------------------
-| 302 (unten)                   | $p(f(b), z) \in P_{f, n-1}(X \setminus \{a\})$                         | $p(f(b), z) \in P_{f, n}(X \setminus \{a\})$ |                                                                                                    |
-| 302 (mittig)                  | \[Wegen Aufgabe 153 gilt\] $\exists x \in U: P_{f, n}(X \setminus \{x\})$ | $\exists x \in U: P_{f, n}(X \setminus \{a\})$ | Die Menge, auf die Bezug genommen wird, ist hier $X \setminus \{a\}$                               |
-| 299 (Lösung Aufgabe 172)      | zeigt Aufgabe 163                                                      | zeigt Aufgabe **171**                        |                                                                                                    |
-| 297 (Lösung Aufgabe 168)      | sei dazu $A \in D_{\alpha * f, n + 1}$                                 | sei dazu $A \in D_{f, n + 1}$                       |                                                                                                    |
-| 295 (unten)                   | $z + f(b) \in S_{n-1}(X \setminus \{a\})$                              | $z + f(b) \in S_{n}(X \setminus \{a\})$  |
-| 288, 289 (Lösung Aufgabe 147) |                               |  | Es wird auf (3.16) Bezug genommen, aber $\forall n \in \N_{>1}: n - 1 \in \N$ ist Axiom **(3.18)** |
+### E Vergleichslösungen
+
+| Seite              | Fehlerstelle                                                                            | Korrekturvorschlag                                                                      | Bemerkung                                                                                                                                                                                                 |
+|--------------------|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| 326 (ML261)        | $0 = dist_d(x, A)inf D_{x,A}$                                                           | $0 = dist_d(x, A) = inf D_{x,A}$                                                        |                                                                                                                                                                                                           |
+| "                  | $a < inf D_{x,A} + \epsilon$                                                            | $u < inf D_{x,A} + \epsilon$                                                            |                                                                                                                                                                                                           |
+| 321 (ML240)        | und $b \in Min(b)$ gegeben                                                              | und $b \in Min(B)$ gegeben                                                              |                                                                                                                                                                                                           |
+| 318 (ML230)        | Zu zeigen ist $\exists D \in \R: \forall y,z \in A : d(x,y) \le D$                      | Zu zeigen ist $\exists D \in \R: \forall y,z \in A : d(y, z) \le D$                     | In der ML wird weiter $d(x,y)$ genutzt, obwohl sich der Allquantor auf $y,z$ bezieht. Das wäre im Weiteren zu überprüfen, da wir mit der Def. von $B_r^d(x)$ auch $d(x, y) < r$ verstehen.
+| 316 (ML226)        | Wir definieren $g: \N_{\le N} \rarr \R,$...                                             | Wir definieren $g: \N_{\le n} \rarr \R,$...                                             |
+| 315 (ML224)        | $d_2(r \cdot u, s \cdot) =$...                                                          | $d_2(r \cdot u, s \cdot u) =$...                                                        |
+| 312 (ML214)        | $L_y = \{\alpha - 3\beta, 3\alpha + 2\beta, 0)/11 + t \cdot (0,2,1)\vert t \in \R\}$    | $L_y = \{3\alpha + 2\beta, \alpha - 3\beta, 0)/11 + t \cdot (0,2,1)\vert t \in \R\}$    | $u, v$ vertauscht
+| 308 (ML194, Ende)  | Da $r \in [u]_\text{\textasciitilde}$ auf $u \in X$ und $u \text{\textasciitilde} x$... | Da $r \in [u]_\text{\textasciitilde}$ auf $u \in X$ und $u \text{\textasciitilde} r$... |
+| 302 (ML178 unten)  | $p(f(b), z) \in P_{f, n-1}(X \setminus \{a\})$                                          | $p(f(b), z) \in P_{f, n}(X \setminus \{a\})$                                            |                                                                                                                                                                                                           |
+| 302 (ML178 mittig) | \[Wegen Aufgabe 153 gilt\] $\exists x \in U: P_{f, n}(X \setminus \{x\})$               | $\exists x \in U: P_{f, n}(X \setminus \{a\})$                                          | Die Menge, auf die Bezug genommen wird, ist hier $X \setminus \{a\}$                                                                                                                                      |
+| 299 (ML172)        | zeigt Aufgabe 163                                                                       | zeigt Aufgabe **171**                                                                   |                                                                                                                                                                                                           |
+| 297 (ML168)        | sei dazu $A \in D_{\alpha \cdot f, n + 1}$                                              | sei dazu $A \in D_{f, n + 1}$                                                           |                                                                                                                                                                                                           |
+| 295 (unten)        | $z + f(b) \in S_{n-1}(X \setminus \{a\})$                                               | $z + f(b) \in S_{n}(X \setminus \{a\})$                                                 |
+| 288, 289 (ML147)   |                                                                                         |                                                                                         | Es wird auf (3.16) Bezug genommen, aber $\forall n \in \N_{>1}: n - 1 \in \N$ ist Axiom **(3.18)**                                                                                                        |
+| 277 (ML106)        |                                                                                         |                                                                                         | für "$\impliedby$" müsste noch $y \in U$ gezeigt werden   
+| 272 (ML89)         |                                                                                         |                                                                                         | Es wird auf eine Symmetrie von $\le$ Bezug genommen, aber in dem Kontext ist $\le$ Antisymmetrisch (**Satz 3.11** und Ü89)
+| 269 (ML78)         | was auf den Widerspruch $0 \ge 1$ führt                                                 | was auf den Widerspruch $1 \ge 2$ führt                                                 | $x \in \N$, also $x \ne 0$. Im indirekten Beweis wird $x \ge x + 1$ mit $x=0$ verwendet
+
+### Ideen: Metrische Räume
+
+| Seite                 | Fehlerstelle             | Korrekturvorschlag                | Bemerkung                                                                                           |
+|-----------------------|--------------------------|-----------------------------------|-----------------------------------------------------------------------------------------------------
+| 166 (Ü274)            | $B_r(A)$                 | $B_r^d(A)$                        |                                                                                                     |
+| 167                   | $B_r(u)$                 | $B_r^d(u)$                        | Mehrfachnennung auf dieser Seite, ohne auf die Metrik Bezug zu nehmen                               |
+| 156 (Ü248)            | $s < sup M$              | $u \in M: u < sup M$              | $s$ ist vorgegeben mit $s \in O_M$, damit gilt ja bereits $s \ge sup M$ und damit auch $s \ge m$    |
+| 154 (Ü240)            | $Min(b)$                 | $Min(B)$                          |                                                                                                     |
+| 148 **Definition 5.9** |                          |                                   | vielleicht bietet es sich hier bereits an, in der Definition den Begriff "offene Kugel" zu verwenden |
+| 147 (Ü226)            | $D: X^n \times X^n$, ... | $D: X^n \times X^n \rarr \R$, ... |  |
+
+### Ideen: Äquivalenzklassen
+
+| Seite                  | Fehlerstelle                                                                    | Korrekturvorschlag                                                                         | Bemerkung                                                                                          |
+|------------------------|---------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------
+| 132 (unten)            | $R([a \cdot u]_\text{\textasciitilde}) = R([a \cdot u]_\text{\textasciitilde})$ | $R(a \boxdot [u]_\text{\textasciitilde}) = R([a \cdot u]_\text{\textasciitilde})$          |                                                                                                    |
+| 118 **Definition 4.1** | Sei $\text{\textasciitilde})$ eine Äquivalenzrelation auf einer Menge $X$       | Sei $\text{\textasciitilde})$ eine Äquivalenzrelation auf einer **nicht leeren** Menge $X$ |                                                                 |
 
 #### Rechtschreibung / Grammatik / Druckfehler
 
 
-| Seite                    | Fehlerstelle                                  | Korrekturvorschlag                              | 
-|--------------------------|-----------------------------------------------|-------------------------------------------------|
-| 295 (Lösung Aufgabe 160) | die Argumentation wurde ist dir eventuell     | die Argumentation ~~wurde~~ ist dir eventuell   |
-| 294                      | zu zeigen ist $P(A)\mid = 2^{\mid A \mid}$    | zu zeigen ist $\mid P(A)\mid = 2^{\mid A \mid}$ |
-| 290                      | ergibt $m = \mid n \mid - \mid A \mid \in \N$ | ergibt $m = n - \mid A \mid \in \N$             |
-| 284 (Lösung Aufgabe 132) | und mit Aufgabe 132 ergibt sich schliesslich   | und mit Aufgabe **131** ergibt sich schliesslich |
+| Seite       | Fehlerstelle                                                       | Korrekturvorschlag                                  | 
+|-------------|--------------------------------------------------------------------|-----------------------------------------------------|
+| 325 (ML259) | Insebsondere ist $dist_d(x,A) = 0$                                 | ~~Insebsondere~~ Insbesondere ist $dist_d(x,A) = 0$ |
+| 295 (ML160) | die Argumentation wurde ist dir eventuell                          | die Argumentation ~~wurde~~ ist dir eventuell       |
+| 294         | zu zeigen ist $P(A)\mid = 2^{\mid A \mid}$                         | zu zeigen ist $\mid P(A)\mid = 2^{\mid A \mid}$     |
+| 290         | ergibt $m = \mid n \mid - \mid A \mid \in \N$                      | ergibt $m = n - \mid A \mid \in \N$                 |
+| 284 (ML132) | und mit Aufgabe 132 ergibt sich schliesslich                       | und mit Aufgabe **131** ergibt sich schliesslich    |
+| 166 (unten) | dass sie sich garnicht scheiden                                    | dass sie sich garnicht ~~scheiden~~ schneiden       |
+| 149         | In einer Kugel mit em Radius                                       | In einer Kugel mit ~~em~~ dem Radius                |
+| 125 (unten) | und mit Aufgabe 179 dann                                           | und mit Aufgabe ~~179~~ 180 dann                    |
+| 120 (oben)  | Mit Teil (b) von Aufgabe 179 folgt hieraus | Mit Teil (b) von Aufgabe ~~179~~ 180 folgt hieraus  |
+| 117         | Ausgangspizza in $a_2 \cdot b_2$ Teile auftritt                    | Ausgangspizza in $a_1 \cdot b_2$ Teile auftritt     |
+
+
+<sup>*</sup>ML = Musterlösung
+
+<sup>*</sup>Ü = Übung
 
 
 


### PR DESCRIPTION
added Vergleichslösungen, Metrische Räume and Äquivalenzklassen.